### PR TITLE
Escape CGI key in regex

### DIFF
--- a/lib/Vend/Server.pm
+++ b/lib/Vend/Server.pm
@@ -296,7 +296,7 @@ sub store_cgi_kv {
 
 	$key = lc ($key) if
 		$Global::DowncaseVarname
-		&& $Global::DowncaseVarname =~ /\b$key\b/i;
+		&& $Global::DowncaseVarname =~ /\b\Q$key\E\b/i;
 
 	$key = $::IV->{$key} if defined $::IV->{$key};
 	if(defined $CGI::values{$key} and ! defined $::SV{$key}) {


### PR DESCRIPTION
Escape cgi key to avoid it being evaluated as a regex, and throwing an exception if it isn't proper (for example, if it has a parenthesis)
