### PR TITLE
Prevent the function to crash when the response is unparsable

### DIFF
--- a/lib/Vend/Payment/PaypalExpress.pm
+++ b/lib/Vend/Payment/PaypalExpress.pm
@@ -911,7 +911,13 @@ sub paypalexpress {
 
  	    $method = SOAP::Data->name('SetExpressCheckoutReq')->attr({xmlns=>$xmlns});
 	    $response = $service->call($header, $method => $request);
-	    %result = %{$response->valueof('//SetExpressCheckoutResponse')};
+
+      my $result_hashref = $response->valueof('//SetExpressCheckoutResponse');
+      unless ($result_hashref) {
+          $Tag->error({ name => 'paypal_failure', set => errmsg('Unable to parse the PayPal response') });
+          return $Tag->deliver({ location => $checkouturl });
+      }
+	    %result = %$result_hashref;
 		$::Scratch->{'token'} = $result{'Token'};
  
    if (!$result{'Token'}) {


### PR DESCRIPTION
Background: it looks like SOAP::Lite sometimes (or always?) fails to escape
some entities (notably &). In this case the charging route crashes, because
$response->valueof('//SetExpressCheckoutResponse') just returns undef.

This patch basically prevent the charge action to complete and set the
redirection to the checkout, the same way as it would have failed for
other reasons.
