### PR TITLE
add better error handling/messaging when no access to database in Safe

### DIFF
--- a/lib/Vend/Data.pm
+++ b/lib/Vend/Data.pm
@@ -985,14 +985,19 @@ sub import_database {
 #::logDebug("ready to try opening db $table_name") if ! $db;
 		eval { 
 			if($MVSAFE::Safe) {
-                if (exists $Vend::Interpolate::Db{$class_config->{Class}}) {
-				    $db = $Vend::Interpolate::Db{$table_name}->open_table( $obj, $obj->{db_file} );
-                } else {
-                    die errmsg("no access for database %s", $table_name);
-                }
+				if (exists $Vend::Interpolate::Db{$class_config->{Class}}) {
+					$db = $Vend::Interpolate::Db{$table_name}->open_table( $obj, $obj->{db_file} );
+				} else {
+					die errmsg("no access for database $table_name. Have you opened the database before trying to access it? You can try inserting [perl $table_name][/perl] in your page before the data access or adding the following to your catalog.cfg: AutoLoad [perl $table_name][/perl]");
+				}
 			}
 			else {
-				$db = $class_config->{Class}->open_table( $obj, $obj->{db_file} );
+				if ($class_config->{Class}->can('open_table')) {
+					$db = $class_config->{Class}->open_table( $obj, $obj->{db_file} );
+				}
+				else {
+					die errmsg("no access for database $table_name. Have you opened the database before trying to access it? You can try inserting [perl $table_name][/perl] in your page before the data access or adding the following to your catalog.cfg: AutoLoad [perl $table_name][/perl]");
+				}
 			}
 			$obj->{NAME} = $db->[$Vend::Table::Common::COLUMN_INDEX]
 				unless defined $obj->{NAME};

--- a/lib/Vend/Table/Common.pm
+++ b/lib/Vend/Table/Common.pm
@@ -631,7 +631,8 @@ sub touch {
 sub ref {
 	my $s = shift;
 	return $s if defined $s->[$TIE_HASH];
-	return $s->import_db();
+	return $s->import_db() if $s->can('import_db');
+	die errmsg("no access for database. Have you opened the database before trying to access it? You can try inserting [perl name_of_table_you_are_accessing][/perl] in your page before the data access or adding the following to your catalog.cfg: AutoLoad [perl name_of_table_you_are_accessing][/perl]");
 }
 
 sub sort_each {


### PR DESCRIPTION
When a db/table has not been pre-opened before attempting to access it in the Safe container, you would usually get a message in the error.log "Can't locate object method open_table via package Vend::Table::DBI"

This commit introduces a more relevant error message along with pointers to help fix the error.

See http://www.icdevgroup.org/pipermail/interchange-users/2018-March/055798.html