### PR TITLE
Add LogTimeFormat global configuration directive

### DIFF
--- a/lib/Vend/Config.pm
+++ b/lib/Vend/Config.pm
@@ -517,6 +517,7 @@ sub global_directives {
 	['ErrorFile',		 'root_dir',   	     undef],
 	['SysLog',			 'hash',     	     undef],
 	['Logging',			 'integer',     	 0],
+	['LogTimeFormat',     undef,             '[%d/%B/%Y:%H:%M:%S %z]'],
 	['CheckHTML',		  undef,     	     ''],
 	['UrlSepChar',		 'url_sep_char',     '&'],
 	['Variable',	  	 'variable',     	 ''],

--- a/lib/Vend/Util.pm
+++ b/lib/Vend/Util.pm
@@ -220,7 +220,7 @@ sub tabbed {
 
 # Returns time in HTTP common log format
 sub logtime {
-    return POSIX::strftime("[%d/%B/%Y:%H:%M:%S %z]", localtime());
+    return POSIX::strftime($Global::LogTimeFormat, localtime());
 }
 
 sub format_log_msg {


### PR DESCRIPTION
The date format for logging provided by logtime claims to be "HTTP common log format". Which is actually not true, it uses %B instead of %b (https://en.wikipedia.org/wiki/Common_Log_Format). While this might seem to be insignificant it prevents Fail2ban to detect the date within Interchange logs.

For backward compatibility and more flexibility I propose a new configuration directive _LogTimeFormat_.

Historical note: the format was never changed since dawn of time (introduction of version control in 2000).