### PR TITLE
Add SMTPConfig directive for Net::SMTP options & SMTP AUTH support

### DIFF
--- a/doc/WHATSNEW-5.12
+++ b/doc/WHATSNEW-5.12
@@ -161,6 +161,9 @@ Core
 * Add new global directive LogTimeFormat which allows customizing the prefix of
   log lines from the default [%d/%B/%Y:%H:%M:%S %z] using strftime(3) format.
 
+* Add new SMTPConfig hash directive for Net::SMTP configuration to support
+  SMTP AUTH user & password, alternate server port, SSL, and timeout options.
+
 
 Payments
 --------

--- a/lib/Vend/Config.pm
+++ b/lib/Vend/Config.pm
@@ -533,6 +533,7 @@ sub global_directives {
 	['ExternalFile',	 'root_dir',	     "$Global::RunDir/external.structure"],
 	['ExternalExport',	 undef,				 'Global::Catalog=Catalog'],
 	['DowncaseVarname',   undef,           ''],
+	['SMTPConfig',		 'hash',			 ''],
 
 	];
 	return $directives;
@@ -742,6 +743,7 @@ sub catalog_directives {
 	['SourceCookie', sub { &parse_ordered_attributes(@_, [qw(name expire domain path secure)]) }, '' ],
 	['SuppressCachedCookies', 'yesno',       'no'],
 	['OutputCookieHook', undef,              ''],
+	['SMTPConfig',		 'hash',			 ''],
 
 	];
 


### PR DESCRIPTION
Add configuration to catalog.cfg and/or interchange.cfg like this:

SendMailProgram Net::SMTP

SMTPConfig <<END
    host smtp.gmail.com
    user you@your.domain
    pass ucogeygtbhbzgayu
    ssl 1
    timeout 5
END

Also available: port (Net::SMTP defaults to 25 when ssl is off, 465 when
ssl is on)

Note that when using user & pass (SMTP AUTH), Net::SMTP requires Authen::SASL.