### PR TITLE
Increase minimum Perl version to 5.16.3

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ use File::Basename;
 use File::Find;
 use Data::Dumper;
 use Cwd;
-require 5.014_001;
+require 5.016_003;
 
 use strict;
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The installation test script.
 
 ## Prerequisites
 
-Interchange requires Perl 5.14.1 or later, on a Unix-like operating
+Interchange requires Perl 5.16.3 or later, on a Unix-like operating
 system. It is primarily used on various Linux distributions, and has
 also been used on FreeBSD, OpenBSD, macOS, and other Unix variants.
 

--- a/SPECS/interchange.spec
+++ b/SPECS/interchange.spec
@@ -27,8 +27,8 @@ Packager: Jon Jensen <jon@endpoint.com>
 Source0: https://ftp.interchangecommerce.org/interchange/5.12/tar/interchange-%{version}.tar.gz
 License: GPL
 Prereq: /sbin/chkconfig, /sbin/service, /usr/sbin/useradd, /usr/sbin/groupadd
-BuildPrereq: perl >= 5.14.1
-Requires: perl >= 5.14.1
+BuildPrereq: perl >= 5.16.3
+Requires: perl >= 5.16.3
 Requires: perl(Safe::Hole)
 Requires: perl(Set::Crontab)
 Requires: interchange = %{version}-%{release}
@@ -381,6 +381,9 @@ fi
 
 
 %changelog
+* Thu Feb 25 2021 Jon Jensen <jon@endpoint.com> 5.12.0-3
+- Increase minimum Perl version to 5.16.3.
+
 * Tue Sep 18 2018 Jon Jensen <jon@endpoint.com> 5.12.0-2
 - Increase minimum Perl version to 5.14.1.
 

--- a/UPGRADE
+++ b/UPGRADE
@@ -7,7 +7,7 @@ Interchange is designed to be drop-in compatible in its major version.
 Briefly summarized, here's what you can expect when upgrading from the
 following versions:
 
- 5.12.x -- The minimum supported Perl version is now 5.14.1.
+ 5.12.x -- The minimum supported Perl version is now 5.16.3.
 
  5.10.x -- A minor bug was fixed in an edge-case usage of the [area] tag which
 	   could result in incompatibility if your code relies on the buggy

--- a/dist/src/cpan_local_install
+++ b/dist/src/cpan_local_install
@@ -7,7 +7,7 @@ use Getopt::Std;
 
 getopts('cfd:h');
 
-require 5.014_001;
+require 5.016_003;
 
 use vars qw/$opt_c $opt_d $opt_h $VERSION/;
 

--- a/dist/src/mod_perl_tlink.pl
+++ b/dist/src/mod_perl_tlink.pl
@@ -3,7 +3,7 @@
 # mod_perl_tlink.pl: runs as a mod_perl program and passes request to
 #                    Interchange server via a TCP socket
 #
-# Copyright (C) 2002-2020 Interchange Development Group
+# Copyright (C) 2002-2021 Interchange Development Group
 # Copyright (C) 1996-2002 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or
@@ -20,7 +20,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Apache::Registry;
 use Socket;

--- a/dist/src/tlink.pl
+++ b/dist/src/tlink.pl
@@ -21,7 +21,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA  02110-1301  USA.
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Socket;
 my $LINK_TIMEOUT = 30;

--- a/dist/src/vlink.pl
+++ b/dist/src/vlink.pl
@@ -21,7 +21,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA  02110-1301  USA.
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Socket;
 my $LINK_FILE    = '~@~INSTALLARCHLIB~@~/etc/socket';

--- a/doc/WHATSNEW-5.12
+++ b/doc/WHATSNEW-5.12
@@ -10,7 +10,7 @@
 
 Interchange 5.12 not released yet
 
-Interchange now requires Perl 5.14.1 or newer.
+Interchange now requires Perl 5.16.3 or newer.
 
 Please note that the official Interchange project site has moved from
 icdevgroup.org to:

--- a/eg/ifdef
+++ b/eg/ifdef
@@ -4,6 +4,8 @@
 #
 # Small script to configure code based on comments
 
+require 5.016_003;
+
 use Getopt::Std;
 
 getopts('nyt:');
@@ -26,10 +28,6 @@ if(!$opt_n and !$opt_y) {
 }
 
 $string = $opt_t || 'DEBUG';
-
-unless($opt_t) {
-	require 5.003_93;
-}
 
 if(! @ARGV) {
 	my @args;

--- a/extensions/Interchange.pm
+++ b/extensions/Interchange.pm
@@ -26,7 +26,7 @@ require Exporter;
 @EXPORT = qw();
 @EXPORT_OK = qw();
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Fcntl;
 use vars qw($VERSION @EXPORT @EXPORT_OK);

--- a/lib/Vend/CounterFile.pm
+++ b/lib/Vend/CounterFile.pm
@@ -74,7 +74,7 @@ systems.  Perhaps we should use the File::Lock module?
 
 Copyright (c) 1995-1998 Gisle Aas. All rights reserved.
 Modifications made by and copyright (C) 2002 Red Hat, Inc.
-and (c) 2002-2007 Interchange Development Group
+and (c) 2002-2021 Interchange Development Group
 
 This library is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
@@ -85,7 +85,7 @@ Gisle Aas <aas@sn.no>
 
 =cut
 
-require 5.014_001;
+require 5.016_003;
 use Carp   qw(croak);
 use Symbol qw(gensym);
 my $rewind_check;

--- a/scripts/interchange.PL
+++ b/scripts/interchange.PL
@@ -56,7 +56,7 @@ use Config;
 no Config;
 
 BEGIN {
-	require 5.014_001;
+	require 5.016_003;
 
 	$ENV{PERL_SIGNALS} ||= 'unsafe';
 
@@ -379,7 +379,7 @@ its web site:
 
 		https://www.interchangecommerce.org/
 
-Interchange requires Perl 5.14.1 or higher; more information on Perl can
+Interchange requires Perl 5.16.3 or higher; more information on Perl can
 be seen at:
 
 		https://www.perl.org/

--- a/scripts/offline.PL
+++ b/scripts/offline.PL
@@ -3,7 +3,7 @@
 #
 # Interchange database builder and indexer
 #
-# Copyright (C) 2002-2018 Interchange Development Group
+# Copyright (C) 2002-2021 Interchange Development Group
 # Copyright (C) 1996-2002 Red Hat, Inc.
 #
 # This program was originally based on Vend 0.2 and 0.3
@@ -29,7 +29,7 @@ use lib '/usr/local/interchange/lib';
 use lib '/usr/local/interchange';
 #use lib '~_~INSTALLARCHLIB~_~';
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Fcntl;
 use Vend::Util;

--- a/scripts/update.PL
+++ b/scripts/update.PL
@@ -3,7 +3,7 @@
 #
 # Interchange database updater
 #
-# Copyright (C) 2002-2018 Interchange Development Group
+# Copyright (C) 2002-2021 Interchange Development Group
 # Copyright (C) 1996-2002 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -26,7 +26,7 @@ use lib '/usr/local/interchange/lib';
 use lib '/usr/local/interchange';
 #use lib '~_~INSTALLARCHLIB~_~';
 
-require 5.014_001;
+require 5.016_003;
 use strict;
 use Fcntl;
 use Vend::Config;


### PR DESCRIPTION
It has been nearly 3 years since I first announced the plan to increase
the minimum Perl version required by Interchange:

https://www.interchangecommerce.org/pipermail/interchange-users/2018-July/055949.html

That plan was uncontroversial among active community members. (The
only counterproposal was to move dramatically faster in deprecating
old Perl versions since most deployments use a custom Perl build.)

The rationale explained there will serve as the ongoing criteria for
our policy to routinely increase the minimum supported Perl version:

Interchange will require a version of Perl at least as new as the oldest
one shipped with one of the three major Linux distributions widely used
for production Interchange deployments: Ubuntu, Debian, and RHEL/CentOS.

The current oldest member of each family is:

RHEL/CentOS 7: 5.16.3
Debian 9: 5.24.1
Ubuntu 16.04 LTS: 5.22.1

Thus we will now require 5.16.3.