### PR TITLE
Usertag [config]

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -288,6 +288,7 @@ code/UserTag/button.tag
 code/UserTag/capture_page.tag
 code/UserTag/child-process.tag
 code/UserTag/component.tag
+code/UserTag/config.tag
 code/UserTag/convert_date.tag
 code/UserTag/css.tag
 code/UserTag/db_date.tag

--- a/code/UserTag/config.tag
+++ b/code/UserTag/config.tag
@@ -13,10 +13,8 @@ sub {
 
     for (split (/[.]/, $key)) {
         $val // do {
-            local $@;
-            $val = eval (sprintf ('$Global::%s', $_)) // '';
-            ::logError(q{Global config key '%s' produced eval error: %s}, $_, $@)
-                if $@;
+            no strict 'refs';
+            $val = ${"Global::$_"};
             next if ref $val;
             last;
         };
@@ -24,7 +22,7 @@ sub {
         if ($test eq 'HASH') {
             $val = $val->{$_};
         }
-        elsif ($test eq 'ARRAY' && /^-?\d+$/) {
+        elsif ($test eq 'ARRAY' && /^-?\d+$/a) {
             $val = $val->[$_];
         }
         else {

--- a/code/UserTag/config.tag
+++ b/code/UserTag/config.tag
@@ -1,0 +1,37 @@
+# Copyright 2002-2021 Interchange Development Group and others
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.  See the LICENSE file for details.
+
+UserTag config Order    key global
+UserTag config Routine  <<EOR
+sub {
+    my ($key, $global) = @_;
+    my $val = $global ? undef : $Vend::Cfg;
+
+    for (split (/[.]/, $key)) {
+        $val // do {
+            local $@;
+            $val = eval (sprintf ('$Global::%s', $_)) // '';
+            ::logError(q{Global config key '%s' produced eval error: %s}, $_, $@)
+                if $@;
+            next if ref $val;
+            last;
+        };
+        my $test = ref $val;
+        if ($test eq 'HASH') {
+            $val = $val->{$_};
+        }
+        elsif ($test eq 'ARRAY' && /^-?\d+$/) {
+            $val = $val->[$_];
+        }
+        else {
+            ::logError(q{Invalid key on [config] call. Dotted key doesn't map to valid HASH or ARRAY reference.});
+            return;
+        }
+    }
+    return $val;
+}
+EOR

--- a/doc/WHATSNEW-5.12
+++ b/doc/WHATSNEW-5.12
@@ -164,6 +164,9 @@ Core
 * Add new SMTPConfig hash directive for Net::SMTP configuration to support
   SMTP AUTH user & password, alternate server port, SSL, and timeout options.
 
+* New usertag [config] to pull catalog config params, or with 2nd-arg flag
+  global config params. Supports dot-syntax for pulling from complex config
+  params.
 
 Payments
 --------


### PR DESCRIPTION
* Returns values out of catalog config hash.

* Adding optional Perly true 2nd parameter instead pulls from global config.

* Use dot syntax to reference complex data.

  E.g., [config Foo.bar.1.baz] returns $Vend::Cfg->{Foo}{bar}[1]{baz}, and
        [config Foo.bar 1] returns $Global::Foo->{bar}