### PR TITLE
Add pragma to prevent order submission without a profile

### DIFF
--- a/dist/strap/catalog.cfg
+++ b/dist/strap/catalog.cfg
@@ -236,6 +236,9 @@ Pragma  strip_white
 # Don't allow <!--[itl tag]-->
 Pragma  no_html_comment_embed
 
+# do not allow orders without a profile
+Pragma require_order_profile
+
 ## DATA INSERTION PRAGMAS for form database inserts or updates
 
 ## Restricts inserts to insert-only, but allows the fall-through

--- a/lib/Vend/Dispatch.pm
+++ b/lib/Vend/Dispatch.pm
@@ -432,6 +432,9 @@ my %form_action = (
 						($status,$final,$missing) =
 							check_order($CGI::values{mv_order_profile});
 					}
+					elsif ($::Pragma->{require_order_profile}) {
+						($status, $final, $missing) = (undef, 0, "Missing profile");
+					}
 					else {
 						$status = $final = 1;
 					}


### PR DESCRIPTION
Previously or without the pragma set, it is possible to trigger the
order routing just posting mv_todo=submit to the process URL.

The pragma is enabled for newly created strap catalogs.