### PR TITLE
Fuller support for DBI quote_identifier()

### DIFF
--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4586,6 +4586,12 @@ sub query {
 			$db->quote($1)
 		:xisge;
 
+	$opt->{query} =~ s{
+			\[\Q$opt->{prefix}\E[_-]quote[-_](ident(?:ifier)?)\](.*?)\[/\Q$opt->{prefix}\E[_-]quote[_-]\1\]
+		}{
+			$db->quote_identifier($2)
+		}xisge;
+
 	if (! $opt->{wantarray} and ! defined $MVSAFE::Safe) {
 		my $result = $db->query($opt, $text);
 		return (ref $result) ? '' : $result;

--- a/lib/Vend/Search.pm
+++ b/lib/Vend/Search.pm
@@ -297,7 +297,7 @@ sub spec_check {
 					push @{$s->{eq_specs}}, $spec;
 					last COLOP unless $s->{dbref};
 					$spec = $s->{dbref}->quote($spec, $s->{mv_search_field}[$i]);
-					$spec = $s->{mv_search_field}[$i] . " = $spec";
+					$spec = $s->{dbref}->quote_identifier($s->{mv_search_field}[$i]) . " = $spec";
 					push(@{$s->{eq_specs_sql}}, $spec);
 				}
 			}

--- a/lib/Vend/Table/Common.pm
+++ b/lib/Vend/Table/Common.pm
@@ -228,6 +228,11 @@ sub quote {
 	return "'$value'";
 }
 
+# Identity function placeholder for Vend::Table::DBI method
+sub quote_identifier {
+	return pop;
+}
+
 sub config {
 	my ($s, $key, $value) = @_;
 	$s = $s->import_db() if ! defined $s->[$TIE_HASH];

--- a/lib/Vend/Table/Shadow.pm
+++ b/lib/Vend/Table/Shadow.pm
@@ -126,6 +126,11 @@ sub quote {
 	return $s->[$OBJ]->quote($value, $field);
 }
 
+# Identity function placeholder for Vend::Table::DBI method
+sub quote_identifier {
+	return pop;
+}
+
 sub numeric {
 	my ($s, $column) = @_;
 	$s = $s->import_db() unless defined $s->[$OBJ];


### PR DESCRIPTION
* Set up new quote_identifier() method to remainder of the datbase abstraction
  layer so that the values of mv_search_field pulled from potentially end-user
  input are escaped as database identifiers before putting them into the
  search query. Already supported in Vend::Table::DBI; remainder of types that
  do not require identifier quoting serve as identity function.

* Introduce [PREFIX-quote-ident] to serve purpose of delegating to
  quote_identifier() for any dynamically generated identifiers in a query to
  protect against SQL injection points.