### PR TITLE
Order check hook

### DIFF
--- a/code/OrderCheck/future.oc
+++ b/code/OrderCheck/future.oc
@@ -23,7 +23,7 @@ sub {
 						  $adjust,
 						 );
 	}
-	if($value =~ /\0/) {
+	if($value =~ /[\0-]/) {
 		$value = Vend::Interpolate::filter_value(
 												 'date_change',
 												 $value,

--- a/lib/Vend/Order.pm
+++ b/lib/Vend/Order.pm
@@ -157,6 +157,11 @@ sub _return {
 	$Success = ( defined($_[1]) && ($_[1] =~ /^[yYtT1]/) ) ? 1 : 0;
 }
 
+sub order_check {
+  reset_order_vars();
+  return _format(@_);
+}
+
 sub _format {
 	my($ref, $params, $message) = @_;
 	no strict 'refs';


### PR DESCRIPTION
Background for this is that we wanted to make use of the form validation routines without calling an mv_check or mv_form_profile.