### PR TITLE
Support foreign parameter in [data] for row return

### DIFF
--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -873,6 +873,8 @@ sub tag_data {
 				);
 	}
 	elsif ($opt->{hash}) {
+		$key = $db->foreign($key, $opt->{foreign})
+			if $opt->{foreign};
 		return undef unless $db->record_exists($key);
 		return $db->row_hash($key);
 	}


### PR DESCRIPTION
Per prior discussion, the foreign param is ignored when asking for the full row to be returned via hash param. Change corrects this deficiency.