### PR TITLE
Pragma set_samesite to control SameSite cookie attributes

### DIFF
--- a/doc/WHATSNEW-5.12
+++ b/doc/WHATSNEW-5.12
@@ -78,7 +78,7 @@ Core
 
   Or for that plus another arbitrary cookie "cart":
 
-  Pragma set_httponly=MV_SESSION_ID,cart
+  Pragma set_httponly=MV_SESSION_ID;cart
 
   The old behavior of setting HttpOnly for all cookies still works as before, e.g.:
 
@@ -167,6 +167,26 @@ Core
 * New usertag [config] to pull catalog config params, or with 2nd-arg flag
   global config params. Supports dot-syntax for pulling from complex config
   params.
+
+* New Pragma set_samesite to control SameSite settings on cookies.
+
+  To set all cookies Strict:
+
+  Pragma set_samesite=Strict
+
+  To set only foo to Lax:
+
+  Pragma set_samesite=foo=Lax
+
+  To add bar as Strict:
+
+  Pragma set_samesite=foo=Lax;bar=Strict
+
+  And add baz as None:
+
+  Pragma set_samesite=foo=Lax;bar=Strict;baz=None
+
+  If None is used, that forces Secure on those cookies as well.
 
 Payments
 --------


### PR DESCRIPTION
* Set all cookies Strict:

  Pragma set_samesite=Strict

* Set single cookie foo to Lax:

  Pragma set_samesite=foo=Lax

* Set multiple cookies semicolon-separated:

  Pragma set_samesite=foo=Lax;bar=Strict;baz=None

* Use of None forces Secure in addition.

* Add feature to WHATSNEW

* Expand parser for set_httponly to include semicolon since Pragma configuration data cannot contain commas.