### PR TITLE
Compression for database sessions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1207,6 +1207,7 @@ lib/Vend/Track.pm
 lib/Vend/UserControl.pm
 lib/Vend/UserDB.pm
 lib/Vend/Util.pm
+lib/Vend/Util/Compress.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files

--- a/lib/Vend/Config.pm
+++ b/lib/Vend/Config.pm
@@ -743,6 +743,7 @@ sub catalog_directives {
 	['SuppressCachedCookies', 'yesno',       'no'],
 	['OutputCookieHook', undef,              ''],
 	['SMTPConfig',		 'hash',			 ''],
+	['SessionDBCompression', undef,            ''],
 
 	];
 

--- a/lib/Vend/Search.pm
+++ b/lib/Vend/Search.pm
@@ -26,7 +26,7 @@ use strict;
 no warnings qw(uninitialized numeric);
 
 use POSIX qw(LC_CTYPE);
-use Vend::Util::Compress;
+use Vend::Util::Compress qw(compress uncompress);
 
 use vars qw($VERSION);
 

--- a/lib/Vend/Search.pm
+++ b/lib/Vend/Search.pm
@@ -26,6 +26,7 @@ use strict;
 no warnings qw(uninitialized numeric);
 
 use POSIX qw(LC_CTYPE);
+use Vend::Util::Compress;
 
 use vars qw($VERSION);
 
@@ -386,7 +387,15 @@ sub more_matches {
 #::logDebug("more_matches: $id from $Vend::Cfg->{SessionDB}");
 			eval {
 				my $db = Vend::Util::dbref($Vend::Cfg->{SessionDB});
-				$obj = Vend::Util::evalr( $db->field($id,'session') );
+				my $out = \$db->field($id,'session');
+				if (my $c_type = $Vend::Cfg->{SessionDBCompression}) {
+					my ($ref, $time, $alert) = uncompress($out, $c_type);
+					::logError("$c_type uncompression response alert: $alert")
+						if $alert;
+					::logDebug('%s time to uncompress: %fs', $c_type, $time);
+					$out = $ref;
+				}
+				$obj = Vend::Util::evalr( $$out );
 			};
 			$@ and return $s->search_error(
 							"Object saved wrong in session DB for search ID %s.",
@@ -1244,7 +1253,16 @@ sub save_more {
 #::logDebug("save_more: $id to Session DB.");
 #::logDebug("save_more:object:" . ::uneval($new));
 		my $db = Vend::Util::dbref($Vend::Cfg->{SessionDB});
-		my $key = $db->set_field($id, 'session', Vend::Util::uneval_fast($new));
+		my $out = \Vend::Util::uneval_fast($new);
+		if (my $c_type = $Vend::Cfg->{SessionDBCompression}) {
+			my ($ref, $before, $after, $time, $alert) = compress($out, $c_type);
+			::logError("$c_type compression response alert: $alert")
+				if $alert;
+			::logDebug('%s compression impact - before: %dB; after: %dB; %%reduced: %s', $c_type, $before, $after, $before ? sprintf ('%.2f', (1-$after/$before)*100) : 'undefined');
+			::logDebug('%s time to compress: %fs', $c_type, $time);
+			$out = $ref;
+		}
+		my $key = $db->set_field($id, 'session', $$out);
 		# explicitly set $@ for check below because some exits from set_field()
 		# never set $@, and it's safer in general not to rely its internals
 		$@ = defined($key) ? undef : 1;

--- a/lib/Vend/SessionDB.pm
+++ b/lib/Vend/SessionDB.pm
@@ -24,7 +24,7 @@ require Tie::Hash;
 
 use strict;
 use Vend::Util;
-use Vend::Util::Compress;
+use Vend::Util::Compress qw(compress uncompress);
 
 use vars qw($VERSION);
 $VERSION = '2.11';

--- a/lib/Vend/Util/Compress.pm
+++ b/lib/Vend/Util/Compress.pm
@@ -25,12 +25,12 @@ package Vend::Util::Compress;
 require Exporter;
 
 use Time::HiRes qw();
-use vars qw($VERSION @EXPORT);
+use vars qw($VERSION @EXPORT_OK);
 $VERSION = '1.0';
 
 @ISA = qw(Exporter);
 
-@EXPORT = qw(
+@EXPORT_OK = qw(
     compress
     uncompress
 );
@@ -93,8 +93,12 @@ eval {
         },
         uncompress => sub {
             my $in = shift;
-            my $out = IO::Uncompress::Brotli::unbro($$in, 30_000_000)
+
+            # Assuming 90% reduction is highly optimistic
+            my ($size) = _byte_size($in);
+            my $out = IO::Uncompress::Brotli::unbro($$in, $size*10)
                 or die "unbro() failed: $!";
+
             return \$out;
         },
     };

--- a/lib/Vend/Util/Compress.pm
+++ b/lib/Vend/Util/Compress.pm
@@ -1,0 +1,202 @@
+# Vend::Util::Compress - Interchange compression management
+#
+# Copyright (C) 2002-2023 Interchange Development Group
+# Copyright (C) 1996-2002 Red Hat, Inc.
+#
+# This program was originally based on Vend 0.2 and 0.3
+# Copyright 1995 by Andrew M. Wilcox <amw@wilcoxsolutions.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+# MA  02110-1301  USA.
+
+package Vend::Util::Compress;
+require Exporter;
+
+use Time::HiRes qw();
+use vars qw($VERSION @EXPORT);
+$VERSION = '1.0';
+
+@ISA = qw(Exporter);
+
+@EXPORT = qw(
+    compress
+    uncompress
+);
+
+use strict;
+use warnings;
+
+my %has;
+eval {
+    require IO::Compress::Zstd;
+    require IO::Uncompress::UnZstd;
+    $has{Zstd} = {
+        compress => sub {
+            my $in = shift;
+            my $out;
+            IO::Compress::Zstd::zstd($in => \$out)
+                or die $IO::Compress::Zstd::ZstdError;
+            return \$out;
+        },
+        uncompress => sub {
+            my $in = shift;
+            my $out;
+            IO::Uncompress::UnZstd::unzstd($in => \$out)
+                or die $IO::Uncompress::UnZstd::UnZstdError;
+            return \$out;
+        },
+    };
+};
+
+eval {
+    require IO::Compress::Gzip;
+    require IO::Uncompress::Gunzip;
+    $has{Gzip} = {
+        compress => sub {
+            my $in = shift;
+            my $out;
+            IO::Compress::Gzip::gzip($in => \$out)
+                or die $IO::Compress::Gzip::GzipError;
+            return \$out;
+        },
+        uncompress => sub {
+            my $in = shift;
+            my $out;
+            IO::Uncompress::Gunzip::gunzip($in => \$out)
+                or die $IO::Uncompress::Gunzip::GunzipError;
+            return \$out;
+        },
+    };
+};
+
+eval {
+    require IO::Compress::Brotli;
+    require IO::Uncompress::Brotli;
+    $has{Brotli} = {
+        compress => sub {
+            my $in = shift;
+            my $out = IO::Compress::Brotli::bro($$in)
+                or die "bro() failed: $!";
+            return \$out;
+        },
+        uncompress => sub {
+            my $in = shift;
+            my $out = IO::Uncompress::Brotli::unbro($$in, 30_000_000)
+                or die "unbro() failed: $!";
+            return \$out;
+        },
+    };
+};
+
+sub compress { wantarray ? _compress_list(@_) : _compress_scalar(@_) }
+
+sub uncompress { wantarray ? _uncompress_list(@_) : _uncompress_scalar(@_) }
+
+sub _compress_scalar {
+    my $ref = shift;
+    my $type = shift;
+
+    my $subs = $has{$type}
+        or do {
+            ::logError("Compression type '$type' is not enabled. Returning original payload.");
+            return $ref;
+        }
+    ;
+
+    local $@;
+    my $out = eval { $subs->{compress}->($ref) }
+        or ::logError('%s compression error - returning original ref - %s', $type, $@);
+
+    return $out // $ref;
+}
+
+sub _compress_list {
+    my $ref = shift;
+    my $type = shift;
+
+    my $subs = $has{$type}
+        or do {
+            my $msg = "Compression type '$type' is not enabled. Returning original payload.";
+            return ($ref, _byte_size($ref) x 2, '0', $msg);
+        }
+    ;
+
+    my $msg = '';
+
+    local $@;
+    my $s = Time::HiRes::time;
+    my $out = eval { $subs->{compress}->($ref) }
+        or $msg = ::errmsg('%s compression error - returning original ref - %s', $type, $@);
+    my $e = Time::HiRes::time;
+
+    $out //= $ref;
+
+    return ($out, _byte_size($ref, $out), $e - $s, $msg);
+}
+
+sub _uncompress_scalar {
+    my $ref = shift;
+    my $type = shift;
+
+    my $subs = $has{$type}
+        or do {
+            ::logError("Compression type '$type' is not enabled. Returning original payload.");
+            return $ref;
+        }
+    ;
+
+    local $@;
+    my $out = eval { $subs->{uncompress}->($ref) }
+        or ::logError('%s uncompression error - %s', $type, $@);
+
+    return $out // $ref;
+}
+
+sub _uncompress_list {
+    my $ref = shift;
+    my $type = shift;
+    my $subs = $has{$type}
+        or do {
+            my $msg = "Compression type '$type' is not enabled. Returning original payload.";
+            return ($ref, '0', $msg);
+        }
+    ;
+
+    my $msg = '';
+
+    local $@;
+    my $s = Time::HiRes::time;
+    my $out = eval { $subs->{uncompress}->($ref) }
+        or $msg = ::errmsg('%s uncompression error - returning original ref - %s', $type, $@);
+    my $e = Time::HiRes::time;
+
+    $out //= $ref;
+
+    return ($out, $e - $s, $msg);
+}
+
+sub _byte_size {
+    my @out;
+
+    use bytes;
+    for (@_) {
+        push @out, length $$_;
+    }
+    return @out;
+}
+
+1;
+
+__END__


### PR DESCRIPTION
* New module Vend::Util::Compress as general interface for compressing and uncompressing scalar data in Interchange. Comes currently defined with:

  + Zstd (preferred)
  + Gzip
  + Brotli

  Additional algorithms can be easily added.

* New catalog config, SessionDBCompression, set to one of the aforementioned values. Empty bypasses compression. An invalid value logs an error and passes through the data unmodified.

* Same compression applies to both session and more lists when MoreDB is also set.

* Vend::Util::Compress exports compress() and uncompress() by default. In scalar context, they return the reference to the scalar holding the transformed data. In list context, they also return additional measurements from the process.

  + compress() returns an array of:
    - $ref
    - $before_size
    - $after_size
    - $elapsed_time
    - $alert

  + uncompress() returns an array of:
    - $ref
    - $elapsed_time
    -  $alert

  + Errors when called in scalar context are written to the catalog error log.

  + Errors when called in list context are returned in $alert.