### PR TITLE
Prevent fatal error if object.mv_results is undefined

### DIFF
--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4894,7 +4894,7 @@ sub tag_loop_list {
 			logError("loop was not passed an arrayref of hashrefs in object.mv_results=`...` argument. Got " . $obj->{mv_results}->[0] . " instead.");
 			return;
 		}
-		$obj->{matches} = scalar(@{$obj->{mv_results}}) if ref $obj->{mv_results} eq 'ARRAY';
+		$obj->{matches} = scalar(@{$obj->{mv_results}});
 		return region($opt, $text);
 	}
 	

--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4889,7 +4889,6 @@ sub tag_loop_list {
 			logError("loop was not passed an arrayref in object.mv_results=`...` argument. Got " . ref($obj->{mv_results}) . " instead.");
 			return;
 		}
-		return unless @{$obj->{mv_results}};
 		$obj->{matches} = scalar(@{$obj->{mv_results}});
 		return region($opt, $text);
 	}

--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4885,6 +4885,15 @@ sub tag_loop_list {
 		my $obj = $opt->{object};
 		# ensure that number of matches is always set
 		# so [on-match] / [no-match] works
+		if (ref($obj->{mv_results}) ne 'ARRAY') {
+			logError("loop was not passed an arrayref in object.mv_results=`...` argument. Got " . ref($obj->{mv_results}) . " instead.");
+			return;
+		}
+		return unless scalar @{$obj->{mv_results}} > 0;
+		if (ref($obj->{mv_results}->[0]) ne 'HASH') {
+			logError("loop was not passed an arrayref of hashrefs in object.mv_results=`...` argument. Got " . $obj->{mv_results}->[0] . " instead.");
+			return;
+		}
 		$obj->{matches} = scalar(@{$obj->{mv_results}}) if ref $obj->{mv_results} eq 'ARRAY';
 		return region($opt, $text);
 	}

--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4885,7 +4885,7 @@ sub tag_loop_list {
 		my $obj = $opt->{object};
 		# ensure that number of matches is always set
 		# so [on-match] / [no-match] works
-		$obj->{matches} = scalar(@{$obj->{mv_results}});
+		$obj->{matches} = scalar(@{$obj->{mv_results}}) if ref $obj->{mv_results} eq 'ARRAY';
 		return region($opt, $text);
 	}
 	

--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4889,7 +4889,7 @@ sub tag_loop_list {
 			logError("loop was not passed an arrayref in object.mv_results=`...` argument. Got " . ref($obj->{mv_results}) . " instead.");
 			return;
 		}
-		return unless scalar @{$obj->{mv_results}} > 0;
+		return unless @{$obj->{mv_results}};
 		$obj->{matches} = scalar(@{$obj->{mv_results}});
 		return region($opt, $text);
 	}

--- a/lib/Vend/Interpolate.pm
+++ b/lib/Vend/Interpolate.pm
@@ -4890,10 +4890,6 @@ sub tag_loop_list {
 			return;
 		}
 		return unless scalar @{$obj->{mv_results}} > 0;
-		if (ref($obj->{mv_results}->[0]) ne 'HASH') {
-			logError("loop was not passed an arrayref of hashrefs in object.mv_results=`...` argument. Got " . $obj->{mv_results}->[0] . " instead.");
-			return;
-		}
 		$obj->{matches} = scalar(@{$obj->{mv_results}});
 		return region($opt, $text);
 	}


### PR DESCRIPTION
If [loop object.mv_results=`$arr_ref`] is used but $arr_ref is undefined the following fatal error will be thrown:

Died in server spawn: Can't use an undefined value as an ARRAY reference at lib/Vend/Interpolate.pm line 4864.

This commit ensures object.mv_results is an Array Ref before derefencing it