### PR TITLE
Allow [convert-date] to display in UTC

### DIFF
--- a/code/UserTag/convert_date.tag
+++ b/code/UserTag/convert_date.tag
@@ -49,13 +49,18 @@ sub {
 					@t = localtime($now) unless $adjust;
 	}
 
-	if ($adjust) {
+	if ($adjust || $opt->{gmt}) {
+		$adjust ||= '';
 		if ($#t < 8) {
 			$t[8] = -1;
 		}
 		$now ||= POSIX::mktime(@t);
 		$adjust .= ' days' if $adjust =~ /^[-\s\d]+$/;
-		@t = localtime(adjust_time($adjust, $now, $opt->{compensate_dst}));
+		my $ts = $adjust
+			? adjust_time($adjust, $now, $opt->{compensate_dst})
+			: $now
+		;
+		@t = $opt->{gmt} ? gmtime($ts) : localtime($ts);
 	}
 
 	if (defined $opt->{raw} and Vend::Util::is_yes($opt->{raw})) {


### PR DESCRIPTION
* New "gmt" flag, to be consistent with flag in [time], that allows output to display the UTC of the input timestamp, or of current time absent an input timestamp. Tag assumes all timestamp input comes from the local timezone.

* Ex:
   [convert-date fmt="%FT%T %Z"]2023-07-04 22:53:18[/convert-date]
       -> displays 2023-07-04T22:53:18 EDT
   [convert-date gmt=1 fmt="%FT%T UTC"]2023-07-04 22:53:18[/convert-date]
       -> displays 2023-07-05T02:53:18 UTC