### PR TITLE
Fix database session locks

### DIFF
--- a/lib/Vend/Session.pm
+++ b/lib/Vend/Session.pm
@@ -387,11 +387,11 @@ sub lock_session {
 	$name ||= $Vend::SessionName;
 #::logDebug ("lock session id=$Vend::SessionID  name=$Vend::SessionName\n");
 	my $lockname = "LOCK_$name";
-	my ($tried, $locktime, $sleepleft, $pid, $now, $left);
+	my ($tried, $sleepleft, $now, $left);
 	$tried = 0;
 
-	LOCKLOOP: {
-		my $lv;
+	LOCKLOOP: while(1) {
+		my ($lv, $locktime, $pid);
 		if (defined ($lv = $Vend::SessionDBM{$lockname}) ) {
 			($locktime, $pid) = split /:/, $lv, 2;
 		}

--- a/lib/Vend/Session.pm
+++ b/lib/Vend/Session.pm
@@ -442,7 +442,8 @@ EOF
 	} #LOCKLOOP
 
 	# Should never get here
-	return undef;
+	logError("lock_session: exited LOCKLOOP unexpectedly");
+	die errmsg("Locking error!\n", '');
 }
 
 sub read_session {


### PR DESCRIPTION
The LOCKLOOP block was missing a while statement which according to Perl docs means that it is semantically identical to a loop that executes once, and a next statement will simply exit the block early.
So, when a session lock was found, it exited out of the LOCKLOOP block, ending up in "# Should never get here", bypassing the lock.

Additionally, the $locktime and $pid variables were not being cleared when the lock was cleared, causing the current pid to write a new lock and use it to block itself indefinitely.