### PR TITLE
Prevent entering session lockloop for non-existent db sessions

### DIFF
--- a/lib/Vend/Session.pm
+++ b/lib/Vend/Session.pm
@@ -466,7 +466,10 @@ sub read_session {
 		};
 		
 #::logDebug ("Session:\n$s\n");
-	return new_session($seed) unless $s;
+	if (!$s) {
+		undef $::Instance->{DB_sessions};
+		return new_session($seed);
+	}
 
     undef $@;
     $Vend::Session = ref $s ? $s : evalr($s);


### PR DESCRIPTION
If a session cookie was sent with an id that no longer existed in the db, the process would get stuck in the lock loop until the HammerLock kicked in.