### PR TITLE
use line directives to improve debugging of UserTags Actions and Subs

### DIFF
--- a/lib/Vend/Config.pm
+++ b/lib/Vend/Config.pm
@@ -2265,15 +2265,15 @@ EOF
 		package Vend::Interpolate;
 		if($nostrict) {
 			no strict;
-			$c->{$name} = eval "#line 1 \"Action $name\"\n" . $sub;
+			$c->{$name} = eval qq(#line 1 "Action $name"\n$sub);
 		}
 		else {
-			$c->{$name} = eval "#line 1 \"Action $name\"\n" . $sub;
+			$c->{$name} = eval qq(#line 1 "Action $name"\n$sub);
 		}
 	}
 	else {
 		package Vend::Interpolate;
-		$c->{$name} = $c->{_mvsafe}->reval("#line 1 \"Action $name\"\n" . $sub);
+		$c->{$name} = $c->{_mvsafe}->reval(qq(#line 1 "Action $name"\n$sub));
 	}
 	if($@) {
 		config_warn("Action '%s' did not compile correctly (%s).", $name, $@);
@@ -5279,7 +5279,7 @@ sub parse_tag {
 		{
 			local $SIG{'__WARN__'} = sub {$fail .= "$_[0]\n";};
 			package Vend::Interpolate;
-			$sub = eval "#line 1 \"UserTag $tag\"\n" . $val;
+			$sub = eval qq(#line 1 "UserTag $tag"\n$val);
 		}
 		if($@) {
 			config_warn(
@@ -5445,16 +5445,16 @@ sub parse_subroutine {
 	$value = $1;
 
 	if(! defined $C) {
-		$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
+		$c->{$name} = eval qq(#line 1 "Sub $name"\n$value);
 	}
 	elsif($perlglobal) {
 		package Vend::Interpolate;
 		if($nostrict) {
 			no strict;
-			$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
+			$c->{$name} = eval qq(#line 1 "Sub $name"\n$value);
 		}
 		else {
-			$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
+			$c->{$name} = eval qq(#line 1 "Sub $name"\n$value);
 		}
 	}
 	else {
@@ -5463,7 +5463,7 @@ sub parse_subroutine {
 		package Vend::Config;
 		$C->{ActionMap} = { _mvsafe => $calc }
 			if ! defined $C->{ActionMap}{_mvsafe};
-		$c->{$name} = $C->{ActionMap}{_mvsafe}->reval("#line 1 \"Sub $name\"\n" . $value);
+		$c->{$name} = $C->{ActionMap}{_mvsafe}->reval(qq(#line 1 "Sub $name"\n$value));
 	}
 
 	config_error("Bad $var '$name': $@") if $@;

--- a/lib/Vend/Config.pm
+++ b/lib/Vend/Config.pm
@@ -2265,15 +2265,15 @@ EOF
 		package Vend::Interpolate;
 		if($nostrict) {
 			no strict;
-			$c->{$name} = eval $sub;
+			$c->{$name} = eval "#line 1 \"Action $name\"\n" . $sub;
 		}
 		else {
-			$c->{$name} = eval $sub;
+			$c->{$name} = eval "#line 1 \"Action $name\"\n" . $sub;
 		}
 	}
 	else {
 		package Vend::Interpolate;
-		$c->{$name} = $c->{_mvsafe}->reval($sub);
+		$c->{$name} = $c->{_mvsafe}->reval("#line 1 \"Action $name\"\n" . $sub);
 	}
 	if($@) {
 		config_warn("Action '%s' did not compile correctly (%s).", $name, $@);
@@ -5279,7 +5279,7 @@ sub parse_tag {
 		{
 			local $SIG{'__WARN__'} = sub {$fail .= "$_[0]\n";};
 			package Vend::Interpolate;
-			$sub = eval $val;
+			$sub = eval "#line 1 \"UserTag $tag\"\n" . $val;
 		}
 		if($@) {
 			config_warn(
@@ -5445,16 +5445,16 @@ sub parse_subroutine {
 	$value = $1;
 
 	if(! defined $C) {
-		$c->{$name} = eval $value;
+		$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
 	}
 	elsif($perlglobal) {
 		package Vend::Interpolate;
 		if($nostrict) {
 			no strict;
-			$c->{$name} = eval $value;
+			$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
 		}
 		else {
-			$c->{$name} = eval $value;
+			$c->{$name} = eval "#line 1 \"Sub $name\"\n" . $value;
 		}
 	}
 	else {
@@ -5463,7 +5463,7 @@ sub parse_subroutine {
 		package Vend::Config;
 		$C->{ActionMap} = { _mvsafe => $calc }
 			if ! defined $C->{ActionMap}{_mvsafe};
-		$c->{$name} = $C->{ActionMap}{_mvsafe}->reval($value);
+		$c->{$name} = $C->{ActionMap}{_mvsafe}->reval("#line 1 \"Sub $name\"\n" . $value);
 	}
 
 	config_error("Bad $var '$name': $@") if $@;


### PR DESCRIPTION
Currently if you have a warning or error in a UserTag, Action, or Sub you will get a message in logs something like this which does not provide context as to where it was thrown:

    Use of uninitialized value in string eq at (eval 5527) line 11.

This change makes use of Perl line directives -
https://perldoc.perl.org/perlsyn#Plain-Old-Comments-%28Not!%29 - to add context so that you get this instead:

    Use of uninitialized value in string eq at UserTag usertag_name line 11.