### PR TITLE
Add tags for shipping rate APIs: UPS and ShipEngine

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -311,12 +311,14 @@ code/UserTag/rand.tag
 code/UserTag/report_table.tag
 code/UserTag/save_cart.tag
 code/UserTag/send_tax_transaction.tag
+code/UserTag/shipengine.tag
 code/UserTag/summary.tag
 code/UserTag/table_organize.tag
 code/UserTag/tax_lookup.tag
 code/UserTag/timed_display.tag
 code/UserTag/title_bar.tag
 code/UserTag/ups_query.tag
+code/UserTag/ups_rest_api.tag
 code/UserTag/usertrack.tag
 code/UserTag/usps_query.tag
 code/UserTag/values_space.tag
@@ -1184,6 +1186,8 @@ lib/Vend/SessionFile.pm
 lib/Vend/Ship.pm
 lib/Vend/Ship/Postal.pm
 lib/Vend/Ship/QueryUPS.pm
+lib/Vend/Ship/ShipEngine.pm
+lib/Vend/Ship/UPS/REST.pm
 lib/Vend/SOAP.pm
 lib/Vend/SOAP/Transport.pm
 lib/Vend/SQL_Parser.pm

--- a/code/UserTag/shipengine.tag
+++ b/code/UserTag/shipengine.tag
@@ -117,7 +117,7 @@ sub {
         if ($res and $res->{data} and $res->{data}->{rate_response} and $res->{data}->{rate_response}->{rates}) {
             my @rates = @{$res->{data}->{rate_response}->{rates}};
             unless (@rates) {
-                @rates = @{$res->{data}->{rate_response}->{invalid_rates}};
+                @rates = @{$res->{data}->{rate_response}->{invalid_rates} || []};
                 $logger->("Using invalid rates");
             }
             foreach my $rate (grep { $_->{service_code} eq $service } @rates) {

--- a/code/UserTag/shipengine.tag
+++ b/code/UserTag/shipengine.tag
@@ -1,0 +1,238 @@
+UserTag shipengine Order mode weight
+UserTag shipengine AddAttr
+UserTag shipengine Routine <<EOR
+sub {
+    my ($mode, $weight, $opts) = @_;
+    my $service = $mode || $opts->{service};
+    require Vend::Ship::ShipEngine;
+    my $logger = sub {
+        my $msg = errmsg(@_);
+        Log($msg, { file => $::Variable->{SHIPENGINE_LOG_FILE} || "var/log/shipengine.log" });
+    };
+    my %args = (
+                logger => $logger,
+                api_key => $::Variable->{SHIPENGINE_API_KEY},
+               );
+    if (my $debug = $::Variable->{SHIPENGINE_DEBUG_FILE}) {
+        $args{tracer} = sub {
+            my $msg = errmsg(@_);
+            Log($msg, { file => $debug });
+        };
+    }
+    my $se = Vend::Ship::ShipEngine->new(%args);
+    if ($opts->{carrier_summary}) {
+        return $se->show_carrier_summary({ json => 1 });
+    }
+    my %from;
+    foreach my $f (qw/name company_name phone
+                      address_line1 address_line2
+                      state_province
+                      city_locality
+                      postal_code country_code
+                     /) {
+        if (my $v = $::Variable->{"SHIPENGINE_FROM_" . uc($f)}) {
+            $from{$f} = $v;
+        }
+    }
+    my %vmap = (
+                name => [qw/fname lname/],
+                company_name => 'company',
+                phone => 'phone_day',
+                address_line1 => 'address1',
+                address_line2 => 'address2',
+                city_locality => 'city',
+                state_province => 'state',
+                postal_code => 'zip',
+                country_code => 'country',
+               );
+    my %to;
+    foreach my $k (keys %vmap) {
+        my $vk = $vmap{$k};
+        if (ref($vk)) {
+            $to{$k} = join(' ', grep { $_ } map { $::Values->{$_} } @$vk);
+        }
+        else {
+            $to{$k} = $::Values->{$vk};
+        }
+    }
+    my $req = {
+               shipment => {
+                            comparison_rate_type => "retail",
+                            ship_from => \%from,
+                            ship_to => \%to,
+                            confirmation => "delivery",
+                            packages => [
+                                         {
+                                          package_code => 'package', # indicates a custom or unknown package type.
+                                          weight => {
+                                                     value => ($weight || 0) + 0,
+                                                     unit => 'pound',
+                                                    },
+                                         },
+                                        ],
+                           },
+               rate_options => {
+                                carrier_ids => [ split(/[ ,]+/, $::Variable->{SHIPENGINE_CARRIERS}) ],
+                               }
+              };
+    my $serialized = $se->serialize_structure($req);
+    my $res;
+    if (my $got = $::Session->{_shipengine_last_request}) {
+        if ($got->{response} and $got->{request} eq $serialized) {
+            if (time() < $got->{expire}) {
+                $res = $got->{response};
+            }
+            else {
+                $se->logger->("Cache expired");
+            }
+        }
+        else {
+            $se->logger->("Cache invalid");
+        }
+    }
+    else {
+        $se->logger->("No cache found");
+    }
+    if (my $got = $::Session->{_shipengine_last_request}) {
+        $logger->("Found the cache in the session");
+        if ($got->{response} and $got->{request} eq $serialized and (time() < $got->{expire})) {
+            $res = $got->{response};
+        }
+    }
+    unless ($res) {
+        $logger->("Doing query for $serialized");
+        $res = $se->api_call(POST => '/v1/rates', $req);
+        if ($res->{data} and $res->{data}->{errors}) {
+            if (ref($res->{data}->{errors}) eq 'ARRAY') {
+                $::Session->{ship_message} .= join(' ', map { $_->{message} // '' } @{$res->{data}->{errors}});
+            }
+        }
+        $::Session->{_shipengine_last_request} = {
+                                                  expire => $res->{success} ? time() + 3600 : time() + 5,
+                                                  request => $serialized,
+                                                  response => $res,
+                                                 };
+    }
+    # now search all the rates for a matching carrier + service
+    my $out = 0;
+    if ($opts->{output_debug}) {
+        return $se->serialize_structure($res->{data}->{rate_response});
+    }
+    if ($service) {
+        if ($res and $res->{data} and $res->{data}->{rate_response} and $res->{data}->{rate_response}->{rates}) {
+            my @rates = @{$res->{data}->{rate_response}->{rates}};
+            unless (@rates) {
+                @rates = @{$res->{data}->{rate_response}->{invalid_rates}};
+                $logger->("Using invalid rates");
+            }
+            foreach my $rate (grep { $_->{service_code} eq $service } @rates) {
+                # pick the highest if multiple
+                my $total = 0;
+                # $logger->("Rate are " . uneval($rate));
+                foreach my $break (qw/requested_comparison/) {
+                    if (my $add = $rate->{"${break}_amount"}) {
+                        if (my $amount = $add->{amount}) {
+                            $total += $amount;
+                        }
+                    }
+                }
+                if ($total > $out) {
+                    $out = $total;
+                }
+            }
+        }
+    }
+    $logger->("Returning $out for $service");
+    return $out;
+}
+EOR
+
+UserTag shipengine Documentation <<EOD
+
+=head1 NAME
+
+shipengine -- calculate shipping rates over the ShipEngine REST API
+
+=head1 SYNOPSIS
+
+  # suitable for shipping.asc
+  [shipengine mode="ups_ground" weight=3]
+
+  # for debugging
+  [shipengine weight=3 output_debug=1]
+  [shipengine show_modes=1]
+
+=head1 DESCRIPTION
+
+Calculate shipping rates over the ShipEngine REST API. See
+L<https://www.shipengine.com/docs/rates/>
+
+The tag is meant to be used in shipping.asc calling it with the mode
+and the total weight:
+
+  [shipengine mode="01" weight="@@TOTAL@@"]
+
+The destination of the packages is taken from the user values.
+
+=head2 OPTIONS
+
+=over 4
+
+=item weight
+
+Weight in pounds. (required)
+
+=item mode
+
+Any supported service code. Call [shipengine carrier_summary=1] to see
+them.
+
+to see them.
+
+=item output_debug
+
+If set to a true value, return all the rate informations collected
+from the API and formatted with JSON.
+
+=item carrier_summary
+
+If set to a true value, return the available carriers and service
+codes with their names.
+
+=back
+
+=head1 VARIABLES
+
+You need this stanza in your catalog.cfg:
+
+  Variable SHIPENGINE_LOG_FILE var/log/shipengine.log
+  # optional debug file with full requests/response
+  # Variable SHIPENGINE_DEBUG_FILE var/log/shipengine.debug.log
+  # to use the sandbox, get a sandbox api key.
+  Variable SHIPENGINE_API_KEY my_api_key_xxxxxxxxxxxxxxxxxxxxxxxxxxx
+  Variable SHIPENGINE_FROM_NAME -
+  Variable SHIPENGINE_FROM_COMPANY_NAME My Company
+  Variable SHIPENGINE_FROM_ADDRESS_LINE1 My Address
+  Variable SHIPENGINE_FROM_PHONE XXX-XXX-XXXX
+  Variable SHIPENGINE_FROM_CITY_LOCALITY My City
+  Variable SHIPENGINE_FROM_POSTAL_CODE 99999
+  Variable SHIPENGINE_FROM_COUNTRY_CODE US
+  Variable SHIPENGINE_FROM_STATE_PROVINCE NY
+  Variable SHIPENGINE_CARRIERS se-11111111 se-2222222
+
+Most of the variables should be clear, as we need to set the origin of
+the package. You need only the ShipEngine API key to get started.
+
+To fill the SHIPENGINE_CARRIERS variable (multiple values separated by
+white space) you need to know the carrier codes. Call:
+
+[shipengine carrier_summary=1]
+
+to get check them and see which shipping modes are
+available for your account.
+
+=head1 AUTHOR
+
+Marco Pessotto <mpessotto@endpointdev.com>, End Point Corp.
+
+EOD

--- a/code/UserTag/shipengine.tag
+++ b/code/UserTag/shipengine.tag
@@ -80,6 +80,7 @@ sub {
     if (my $got = $::Session->{_shipengine_last_request}) {
         if ($got->{response} and $got->{request} eq $serialized) {
             if (time() < $got->{expire}) {
+                $se->logger->("Using cached response");
                 $res = $got->{response};
             }
             else {
@@ -92,12 +93,6 @@ sub {
     }
     else {
         $se->logger->("No cache found");
-    }
-    if (my $got = $::Session->{_shipengine_last_request}) {
-        $logger->("Found the cache in the session");
-        if ($got->{response} and $got->{request} eq $serialized and (time() < $got->{expire})) {
-            $res = $got->{response};
-        }
     }
     unless ($res) {
         $logger->("Doing query for $serialized");
@@ -187,8 +182,6 @@ Weight in pounds. (required)
 Any supported service code. Call [shipengine carrier_summary=1] to see
 them.
 
-to see them.
-
 =item output_debug
 
 If set to a true value, return all the rate informations collected
@@ -228,8 +221,8 @@ white space) you need to know the carrier codes. Call:
 
 [shipengine carrier_summary=1]
 
-to get check them and see which shipping modes are
-available for your account.
+to check them and see which shipping modes are available for your
+account.
 
 =head1 AUTHOR
 

--- a/code/UserTag/ups_rest_api.tag
+++ b/code/UserTag/ups_rest_api.tag
@@ -65,16 +65,6 @@ sub {
                         CountryCode => $to{country},
                     },
                 },
-                ShipFrom =>  {
-                    Name =>  $from{name},
-                    Address =>  {
-                        AddressLine =>  [ grep { $_ } ($from{address1}, $from{address2}) ],
-                        City =>  $from{city},
-                        StateProvinceCode =>  $from{state},
-                        PostalCode =>  $from{zip},
-                        CountryCode => $from{country},
-                    }
-                },
                 NumOfPieces =>  "1",
                 Package =>  {
                     PackagingType =>  {

--- a/code/UserTag/ups_rest_api.tag
+++ b/code/UserTag/ups_rest_api.tag
@@ -1,0 +1,296 @@
+UserTag ups_rest_api Order mode weight
+UserTag ups_rest_api addAttr
+UserTag ups_rest_api Routine <<EOR
+sub {
+    my ($mode, $weight, $opts) = @_;
+    require Vend::Ship::UPS::REST;
+    my $logger = sub {
+        my $msg = errmsg(@_);
+        Log($msg, { file => $::Variable->{UPS_REST_API_LOG_FILE} || "var/log/ups_rest_api.log" });
+    };
+    my %args = (
+                logger => $logger,
+                cache_dir => $::Variable->{UPS_REST_API_CACHE_DIR} || "var/ups_rest_api",
+               );
+    foreach my $k (qw/client_id client_secret endpoint/) {
+        $args{$k} = $Variable->{'UPS_REST_API_' . uc($k)};
+        unless ($args{$k}) {
+            $logger->("Missing mandatory setting $k");
+            return;
+        }
+    }
+    if (my $debug = $::Variable->{UPS_REST_API_DEBUG_FILE}) {
+        $args{tracer} = sub {
+            my $msg = errmsg(@_);
+            Log($msg, { file => $debug });
+        };
+    }
+    my $ups = Vend::Ship::UPS::REST->new(%args);
+    if ($opts->{show_modes}) {
+        return $ups->serialize_structure_pp($ups->service_codes);
+    }
+    my (%from, %to);
+    foreach my $k (qw/name address1 address2 city state zip country shipper_number/) {
+        $from{$k} = $::Variable->{'UPS_REST_API_FROM_' . uc($k) };
+    }
+    foreach my $k (qw/fname lname company address1 address2 city state zip country/) {
+        $to{$k} = $::Values->{$k};
+    }
+    my $req = {
+        RateRequest =>  {
+            Request =>  {
+                TransactionReference =>  {
+                    CustomerContext =>  'dummy',
+                },
+            },
+            Shipment =>  {
+                Shipper =>  {
+                    Name =>  $from{name},
+                    ShipperNumber =>  $from{shipper_number},
+                    Address =>  {
+                        AddressLine =>  [ grep { $_ } ($from{address1}, $from{address2}) ],
+                        City =>  $from{city},
+                        StateProvinceCode =>  $from{state},
+                        PostalCode =>  $from{zip},
+                        CountryCode => $from{country},
+                    }
+                },
+                ShipTo =>  {
+                    Name =>  join(' ', grep { $_ } ($to{fname}, $to{lname}, $to{company})),
+                    Address =>  {
+                        AddressLine =>  [ grep { $_ } ($to{address1}, $to{address2}) ],
+                        City =>  $to{city},
+                        StateProvinceCode =>  $to{state},
+                        PostalCode =>  $to{zip},
+                        CountryCode => $to{country},
+                    },
+                },
+                ShipFrom =>  {
+                    Name =>  $from{name},
+                    Address =>  {
+                        AddressLine =>  [ grep { $_ } ($from{address1}, $from{address2}) ],
+                        City =>  $from{city},
+                        StateProvinceCode =>  $from{state},
+                        PostalCode =>  $from{zip},
+                        CountryCode => $from{country},
+                    }
+                },
+                NumOfPieces =>  "1",
+                Package =>  {
+                    PackagingType =>  {
+                        Code =>  "02",
+                        Description =>  "Packaging"
+                    },
+                    Dimensions =>  {
+                        UnitOfMeasurement =>  {
+                            Code =>  "IN",
+                            Description =>  "Inches"
+                        },
+                        Length =>  "1",
+                        Width =>  "1",
+                        Height =>  "1",
+                    },
+                    PackageWeight =>  {
+                        UnitOfMeasurement =>  {
+                            Code =>  "LBS",
+                            Description =>  "Pounds"
+                        },
+                        Weight =>  $weight,
+                    },
+                }
+            }
+        }
+    };
+    if ($::Variable->{UPS_REST_API_NEGOTIATED_RATES}) {
+        $req->{RateRequest}->{Shipment}->{ShipmentRatingOptions}->{NegotiatedRatesIndicator} = "Y";
+    }
+    my $serialized = $ups->serialize_structure($req);
+    my $res;
+    if (my $got = $::Session->{_ups_rest_api_last_request}) {
+        if ($got->{response} and $got->{request} eq $serialized) {
+            if (time() < $got->{expire}) {
+                # $ups->logger->("Using cached response");
+                $res = $got->{response};
+            }
+            else {
+                $ups->logger->("Cache expired");
+            }
+        }
+        else {
+            $ups->logger->("Cache invalid");
+        }
+    }
+    else {
+        $ups->logger->("No cache found");
+    }
+    unless ($res) {
+        $ups->logger->("Doing actual call");
+        # populate the id after the caching
+        $req->{RateRequest}->{Request}->{TransactionReference}->{CustomerContext} = sprintf('rate-%s-%s',
+                                                                                            $::Session->{ohost},
+                                                                                            time());
+        $res = $ups->safe_api_call(POST => '/api/rating/v2403/Shop' => $req);
+        if ($res->{data}
+            and $res->{data}->{response}
+            and $res->{data}->{response}->{errors}) {
+            my $errors = $res->{data}->{response}->{errors};
+            if (ref($errors) eq 'ARRAY') {
+                $::Session->{ship_message} .= join(' ', map { $_->{message} // '' } @$errors);
+            }
+        }
+        $::Session->{_ups_rest_api_last_request} = {
+                                                  expire => $res->{success} ? time() + 3600 : time() + 5,
+                                                  request => $serialized,
+                                                  response => $res,
+                                                 };
+    }
+    my $service_codes = $ups->service_codes;
+    my @all;
+    if ($res->{success}
+        and $res->{data}
+        and $res->{data}->{RateResponse}
+        and $res->{data}->{RateResponse}->{RatedShipment}
+        and ref($res->{data}->{RateResponse}->{RatedShipment}) eq 'ARRAY') {
+        foreach my $shipment (@{ $res->{data}->{RateResponse}->{RatedShipment} }) {
+            my $rate = {
+                service_code => $shipment->{Service}->{Code},
+                published_rate => $shipment->{TotalCharges}->{MonetaryValue},
+            };
+            if (my $negotiated = $shipment->{NegotiatedRateCharges}) {
+                $rate->{negotiated} = $negotiated->{TotalCharge}->{MonetaryValue};
+            }
+            $rate->{service_name} = $service_codes->{$rate->{service_code}} || {};
+            push @all, $rate;
+        }
+    }
+    if ($opts->{output_debug}) {
+        return $ups->serialize_structure_pp(\@all);
+    }
+    my $out = 0;
+    if ($mode) {
+        my $selected;
+      RATE:
+        foreach my $rate (@all) {
+            if ($rate->{service_code} eq $mode) {
+                $selected = $rate;
+                last RATE;
+            }
+            else {
+                foreach my $alias (@{ $rate->{service_name}->{aliases} || []}) {
+                    if (lc($mode) eq lc($alias)) {
+                        $selected = $rate;
+                        last RATE;
+                    }
+                }
+            }
+        }
+        if ($selected) {
+            $ups->logger->("Selected rate is " . ::uneval($selected));
+            $out = $selected->{negotiated} || $selected->{published_rate};
+        }
+    }
+    return $out;
+}
+EOR
+
+UserTag ups_rest_api Documentation <<EOD
+
+=head1 NAME
+
+ups-rest-api -- calculate UPS rates over the REST API
+
+=head1 SYNOPSIS
+
+  # suitable for shipping.asc
+  [ups-rest-api mode="upsg" weight=3]
+
+  # for debugging
+  [ups-rest-api weight=3 output_debug=1]
+  [ups-rest-api show_modes=1]
+
+=head1 DESCRIPTION
+
+Calculate UPS rates over the REST API. The tag is meant to be used in
+shipping.asc calling it with the mode and the total weight:
+
+  [ups-rest-api mode="01" weight="@@TOTAL@@"]
+
+The destination of the packages is taken from the user values.
+
+=head2 OPTIONS
+
+=over 4
+
+=item weight
+
+Weight in pounds. (required)
+
+=item mode
+
+Any UPS service code: See
+L<https://developer.ups.com/api/reference/shipping/appendix2?loc=en_US>
+
+You can also pass legacy codes like C<upsg>. Call [ups-rest-api show_modes=1]
+to see them.
+
+=item output_debug
+
+If set to a true value, return all the rate informations collected
+from the API and formatted with JSON.
+
+=item show_modes
+
+If set to a true value, return the available service codes with their
+names and the supported aliases.
+
+=back
+
+=head1 VARIABLES
+
+If called without the proper variables set, this tag will crash.
+
+You need this stanza in your catalog.cfg:
+
+  Variable UPS_REST_API_LOG_FILE var/log/ups_rest_api.log
+  # optional debug file with full requests/response
+  Variable UPS_REST_API_DEBUG_FILE var/log/ups_rest_api.debug.log
+  Variable UPS_REST_API_CLIENT_ID XXXXXX
+  Variable UPS_REST_API_CLIENT_SECRET XXXXXXX
+  # production endpoint:
+  # Variable UPS_REST_API_ENDPOINT https://onlinetools.ups.com
+  # this is the sandbox:
+  Variable UPS_REST_API_ENDPOINT https://wwwcie.ups.com
+  Variable UPS_REST_API_NEGOTIATED_RATES 1
+  Variable UPS_REST_API_FROM_NAME My Company
+  Variable UPS_REST_API_FROM_SHIPPER_NUMBER XXXXXX
+  Variable UPS_REST_API_FROM_ADDRESS1 My Address
+  Variable UPS_REST_API_FROM_CITY My City
+  Variable UPS_REST_API_FROM_STATE NY
+  Variable UPS_REST_API_FROM_ZIP 99999
+  Variable UPS_REST_API_FROM_COUNTRY US
+
+Most of the variables should be clear, as we need to set the origin of
+the package. As shown above, there are two endpoints available, one
+for the sandbox and one for production.
+
+Set C<UPS_REST_API_NEGOTIATED_RATES> to a true value if you have
+negotiated rates.
+
+To get the client id and the client secret, you need to login and
+create an App at L<https://developer.ups.com/apps>. You only need to
+subscribe to the Rating API.
+
+The Shipper Number is called "Billing Account Number" in the App page
+where you can find the credentials.
+
+=head1 AUTHOR
+
+Marco Pessotto <mpessotto@endpointdev.com>, End Point Corp.
+
+EOD
+
+
+# Local Variables:
+# mode: cperl
+# cperl-indent-parens-as-block: t
+# End:

--- a/lib/Vend/Ship/ShipEngine.pm
+++ b/lib/Vend/Ship/ShipEngine.pm
@@ -1,0 +1,114 @@
+package Vend::Ship::ShipEngine;
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+# in cpanfile
+use LWP::UserAgent;
+use JSON (qw/encode_json decode_json/);
+
+sub new {
+    my ($class, %args) = @_;
+    my $ua = LWP::UserAgent->new(timeout => 30);
+    my $self = {
+                logger => sub {},
+                tracer => sub {},
+                ua => $ua,
+                api_key => undef,
+               };
+    foreach my $k (keys %$self) {
+        if (defined $args{$k}) {
+            $self->{$k} = $args{$k};
+        }
+        die "$k is required" unless $self->{$k};
+    }
+    bless $self, $class;
+}
+
+sub api_key { shift->{api_key} }
+sub tracer  { shift->{tracer} }
+sub logger  { shift->{logger} }
+sub ua      { shift->{ua} }
+
+sub serialize_structure {
+    my ($self, $struct) = @_;
+    return JSON->new->canonical->ascii->pretty->encode($struct);
+}
+
+sub api_call {
+    my ($self, @args) = @_;
+    my %out;
+    eval {
+        my $res = $self->_api_call(@args);
+        if ($res->content_type =~ m{application/json}i) {
+            if (my $content = $res->content) {
+                $out{data} = decode_json($content);
+            }
+            else {
+                $out{data} = undef;
+            }
+        }
+        else {
+            $out{text} = $res->decoded_content;
+        }
+        $out{success} = $res->is_success;
+    };
+    if ($@) {
+        $out{error} = $@;
+    }
+    return \%out;
+}
+
+sub _api_call {
+    my ($self, $method, $path, $payload, $options) = @_;
+    die "Bad usage" unless $method && $path;
+    my $p = $payload ? encode_json($payload) : '';
+    $self->tracer->("Payload is " . Dumper($payload));
+    my @args = ($method);
+    my $uri = URI->new('https://api.shipengine.com');
+    $uri->path($path);
+    $uri->query_form({
+                      %{ $options || {} }
+                     });
+    push @args, $uri, [
+                       'API-Key' => $self->api_key,
+                       'Content-Type' => 'application/json',
+                       'Accept' => 'application/json',
+                      ];
+    push @args, $p if $p;
+    my $req = HTTP::Request->new(@args);
+    $self->tracer->($req->as_string);
+    my $res = $self->ua->request($req);
+    $self->tracer->($res->as_string);
+    return $res;
+}
+
+sub show_carrier_summary {
+    my ($self, $opts) = @_;
+    my $res = $self->api_call(GET => '/v1/carriers');
+    my @out;
+    if ($res->{success} and $res->{data}) {
+        foreach my $carrier (@{$res->{data}->{carriers} || []}) {
+            my $details = {
+                           carrier_code => $carrier->{carrier_code},
+                           carrier_id => $carrier->{carrier_id},
+                           services => [],
+                           packages => [],
+                          };
+            foreach my $service (@{ $carrier->{services} || [] }) {
+                push @{$details->{services}}, "$service->{service_code}: $service->{name}";
+            }
+            foreach my $package (@{ $carrier->{packages} || [] }) {
+                push @{$details->{packages}}, "$package->{package_code}: $package->{name}";
+            }
+            push @out, $details;
+        }
+    }
+    if ($opts->{json}) {
+        return JSON->new->canonical->ascii->pretty->encode(\@out);
+    }
+    return \@out;
+}
+
+1;

--- a/lib/Vend/Ship/UPS/REST.pm
+++ b/lib/Vend/Ship/UPS/REST.pm
@@ -1,0 +1,247 @@
+package Vend::Ship::UPS::REST;
+
+use strict;
+use warnings;
+
+# http://perlpunks.de/corelist/
+use File::Spec::Functions qw/catfile catdir/;
+use File::Path ();
+use File::Copy qw/move/;
+use Data::Dumper;
+# in cpanfile
+use JSON;
+use LWP::UserAgent;
+# lwp's deps
+use URI;
+use HTTP::Headers;
+use HTTP::Request;
+
+sub new {
+    my ($class, %args) = @_;
+    my $ua = LWP::UserAgent->new(timeout => 30);
+    my $self = {
+                endpoint => undef,
+                client_id => undef,
+                client_secret => undef,
+                cache_dir => 'var/ups_rest_api',
+                logger => sub {},
+                tracer => sub {},
+                ua => $ua,
+               };
+    foreach my $k (keys %$self) {
+        if (defined $args{$k}) {
+            $self->{$k} = $args{$k};
+        }
+        die "$k is required" unless $self->{$k};
+    }
+    bless $self, $class;
+}
+
+sub endpoint      { shift->{endpoint} };
+sub client_id     { shift->{client_id} };
+sub client_secret { shift->{client_secret} };
+sub cache_dir     { shift->{cache_dir} };
+sub logger        { shift->{logger} };
+sub tracer        { shift->{tracer} };
+sub ua            { shift->{ua} };
+
+sub oath_token_endpoint {
+    my $self = shift;
+    my $uri = URI->new($self->endpoint);
+    $uri->path('/security/v1/oauth/token');
+    return $uri;
+}
+
+sub cache_file {
+    my $self = shift;
+    $self->{cache_file} ||= $self->_build_cache_file;
+    return $self->{cache_file};
+}
+
+sub _build_cache_file {
+    my $self = shift;
+    my $dir = $self->cache_dir or die "missing cache_dir";
+    File::Path::make_path($dir, { chmod => 0700 });
+    return File::Spec->catfile($dir, 'token.json');
+}
+
+sub get_new_token {
+    my $self = shift;
+    my $h = HTTP::Headers->new('Content-Type' => 'application/x-www-form-urlencoded');
+    $self->logger->("Requiring new token");
+    $h->authorization_basic($self->client_id, $self->client_secret);
+    my $req = HTTP::Request->new(POST => $self->oath_token_endpoint, $h,
+                                 'grant_type=client_credentials');
+    # $self->logger->($req->as_string);
+    my $res = $self->ua->request($req);
+    $self->tracer->("Token request " . join(" ", $req->as_string, $res->as_string));
+    if ($res->is_success) {
+        my $content = $res->content;
+        my $data = decode_json($content);
+        my $temporary = $self->cache_file . $$ . time();
+        open (my $fh, '>:raw', $temporary) or die "Cannot open $temporary $!";
+        print $fh $content;
+        close $fh;
+        # atomic write
+        move($temporary, $self->cache_file);
+        return $data;
+    }
+    else {
+        die "Cannot retrieve the token! Status line is "
+          . $res->status_line . " " . ($res->content || '');
+    }
+}
+
+sub get_token {
+    my $self = shift;
+    my $cache = $self->cache_file;
+    my $data;
+    # get from file if exists
+    if (-f $cache) {
+        open (my $fh, '<:raw', $cache) or die "Cannot open $cache $!";
+        local $/ = undef;
+        my $json = <$fh>;
+        close $fh;
+        eval {
+            $data = decode_json($json);
+        };
+        my $mtime = (stat($cache))[9];
+        if ($data->{expires_in}
+            and $data->{access_token}
+            and ((time() - $mtime + 60) < $data->{expires_in})) {
+            return $data;
+        }
+    }
+    return $self->get_new_token;
+}
+
+sub safe_api_call {
+    my ($self, @args) = @_;
+    my $ret;
+    eval {
+        $ret = $self->api_call(@args);
+    };
+    if (my $err = $@) {
+        $self->logger->("Fatal error: $err");
+        $ret = {
+                data => undef,
+                error => "$err",
+               };
+    }
+    return $ret;
+}
+
+sub api_call {
+    my ($self, @args) = @_;
+    my $res = $self->_do_api_call(@args);
+    # if 401 get a new token and repeat.
+    if (!$res->is_success and $res->code == 401) {
+        $self->get_new_token;
+        $res = $self->_do_api_call(@args);
+    }
+    my %out = (
+               text => $res->decoded_content,
+               request => \@args,
+              );
+    if ($res->content_type =~ m{application/json}i) {
+        if (my $content = $res->content) {
+            $out{data} = decode_json($content);
+        }
+        else {
+            $out{data} = undef;
+        }
+    }
+    if ($res->is_success) {
+        $out{success} = 1;
+    }
+    else {
+        $out{error} = "Failure " . $res->status_line . ": " . $out{text};
+        $self->logger->($out{error});
+    }
+    return \%out;
+}
+
+sub _do_api_call {
+    my ($self, $method, $path, $payload, $options) = @_;
+    die "Bad usage" unless $method && $path;
+    my $p = $payload ? encode_json($payload) : '';
+    my @args = ($method);
+    my $uri = URI->new($self->endpoint);
+    $uri->path($path);
+    if ($options) {
+        $uri->query_form($options);
+    }
+    push @args, $uri, [
+                       'Content-Type' => 'application/json',
+                       Authorization => "Bearer " . $self->get_token->{access_token},
+                      ];
+    push @args, $p if $p;
+
+    $self->logger->(qq{$method $uri $p});
+    my $req = HTTP::Request->new(@args);
+    $self->tracer->("My request is " . $req->as_string);
+    my $res = $self->ua->request($req);
+    $self->tracer->("My response is " . $res->as_string);
+    $self->logger->("Status line is " . $res->status_line);
+    return $res;
+}
+
+
+# https://developer.ups.com/api/reference/shipping/appendix2?loc=en_US + [ups-net-query]
+sub service_codes {
+
+    # legacy codes from ups-net-query.tag Unclear UPS_SAVER what is it
+# 	my %service = (
+#       '1DA' => 'NEXT_DAY_AIR',
+#       'upsr' => 'NEXT_DAY_AIR',
+#       '2DA' => '2ND_DAY_AIR',
+#       'upsb' => '2ND_DAY_AIR',
+#       'GND' => 'GROUND',
+#       'upsg' => 'GROUND',
+#       'XPR' => 'WORLDWIDE_EXPRESS',
+#       'XPD' => 'WORLDWIDE_EXPEDITED',
+#       'STD' => 'STANDARD',
+#       'cang' => 'STANDARD',
+#       '3DS' => '3_DAY_SELECT',
+#       'ups3' => '3_DAY_SELECT',
+#       '1DP' => 'NEXT_DAY_AIR_SAVER',
+#       'upsrs' => 'NEXT_DAY_AIR_SAVER',
+#       '1DM' => 'NEXT_DAY_AIR_EARLY_AM',
+#       'XDM' => 'WORLDWIDE_EXPRESS_PLUS',
+#       '2DM' => '2ND_DAY_AIR_AM',
+#       'upsbam' => '2ND_DAY_AIR_AM',
+#       'SVR' => 'UPS_SAVER',
+# 	);
+    #  Shipments originating in United States
+
+    return {
+            '11' => { name => "UPS Standard", aliases => [qw/STD cang/] },
+            '08' => { name => "UPS Worldwide Expedited", aliases => [qw/XPD/] },
+            '07' => { name => "UPS Worldwide Express", aliases => [qw/XPR/] },
+            '54' => { name => "UPS Worldwide Express Plus", aliases => [qw/XDM/] },
+            '65' => { name => "UPS Worldwide Saver", aliases => [qw//] },
+            '02' => { name => "UPS 2nd Day Air", aliases => [qw/2DA upsb/] },
+            '59' => { name => "UPS 2nd Day Air A.M.", aliases => [qw/2DM upsbam/] },
+            '12' => { name => "UPS 3 Day Select", aliases => [qw/3DS ups3/] },
+            'M4' => { name => "UPS Expedited Mail Innovations", aliases => [qw//] },
+            'M2' => { name => "UPS First-Class Mail", aliases => [qw//] },
+            '03' => { name => "UPS Ground", aliases => [qw/GND upsg/] },
+            '01' => { name => "UPS Next Day Air", aliases => [qw/1DA upsr/] },
+            '14' => { name => "UPS Next Day Air Early", aliases => [qw/1DM/] },
+            '13' => { name => "UPS Next Day Air Saver", aliases => [qw/1DP upsrs/] },
+            'M3' => { name => "UPS Priority Mail", aliases => [qw//] },
+           };
+}
+
+sub serialize_structure {
+    my ($self, $struct) = @_;
+    return JSON->new->canonical->ascii->encode($struct);
+}
+
+sub serialize_structure_pp {
+    my ($self, $struct) = @_;
+    return JSON->new->canonical->ascii->pretty->encode($struct);
+}
+
+1;
+

--- a/lib/Vend/Ship/UPS/REST.pm
+++ b/lib/Vend/Ship/UPS/REST.pm
@@ -45,7 +45,7 @@ sub logger        { shift->{logger} };
 sub tracer        { shift->{tracer} };
 sub ua            { shift->{ua} };
 
-sub oath_token_endpoint {
+sub oauth_token_endpoint {
     my $self = shift;
     my $uri = URI->new($self->endpoint);
     $uri->path('/security/v1/oauth/token');
@@ -70,7 +70,7 @@ sub get_new_token {
     my $h = HTTP::Headers->new('Content-Type' => 'application/x-www-form-urlencoded');
     $self->logger->("Requiring new token");
     $h->authorization_basic($self->client_id, $self->client_secret);
-    my $req = HTTP::Request->new(POST => $self->oath_token_endpoint, $h,
+    my $req = HTTP::Request->new(POST => $self->oauth_token_endpoint, $h,
                                  'grant_type=client_credentials');
     # $self->logger->($req->as_string);
     my $res = $self->ua->request($req);


### PR DESCRIPTION
Both tags work in the same way. After retrieving the credentials from their dashboard, [ups-rest-api] and [shipengine] can be used in the shipping.asc definitions, passing the relevant mode and the package weight.

They come with the documentation explaining which variables to set in the catalog configuration.