### PR TITLE
Make Vend::Table::Common really exportable

### DIFF
--- a/lib/Vend/Table/Common.pm
+++ b/lib/Vend/Table/Common.pm
@@ -46,6 +46,7 @@ else {
 }
 
 use Exporter;
+our @ISA = qw(Exporter);
 use vars qw($Storable $VERSION @EXPORT @EXPORT_OK);
 @EXPORT = qw(create_columns import_ascii_delimited import_csv config columns);
 @EXPORT_OK = qw(import_quoted read_quoted_fields);


### PR DESCRIPTION
Vend::Table::Common define @EXPORT and @EXPORT_OK, but does not set the @ISA hence import the methods will not work.

Vend::Data has:

  use Vend::Table::Common qw(import_ascii_delimited);

Vend::Table::InMemory has:

  use Vend::Table::Common qw(!config !columns);

On perl 5.36 they silently fail (and in those modules the functions are called with the namespace).

On perl 5.40 it produces these noisy warnings:

Attempt to call undefined import method with arguments ("!config" ...) via package "Vend::Table::Common" (Perhaps you forgot to load the package?) at /home/marco/camp14/interchange/lib/Vend/Table/InMemory.pm line 25.

Attempt to call undefined import method with arguments ("import_ascii_delimited") via package "Vend::Table::Common" (Perhaps you forgot to load the package?) at
/home/marco/camp14/interchange/lib/Vend/Data.pm line 66.

The other fix would be to remove the exporting altogether from Vend::Table::Common and do not (try to) import methods in those two modules.