### PR TITLE
PreFork: stop HUP relay from killing page servers; jobs queue and payment timeout hardening

### DIFF
--- a/lib/Vend/Control.pm
+++ b/lib/Vend/Control.pm
@@ -50,7 +50,7 @@ sub signal_reconfig {
 }
 
 sub signal_jobs {
-	shift;
+	my $queue_only = shift eq 'queuejobs';
 	$Vend::mode = 'jobs';
 	my $arg = shift;
 	my ($cat, $job, $delay) = split /\s*=\s*/, $arg, 3;
@@ -79,6 +79,18 @@ sub signal_jobs {
 	
 	write_jobsqueue("jobs $cat $delay $job$parmsstr\n");
 #::logGlobal("signal_jobs: wrote file, ready to control_interchange");
+
+	if ($queue_only) {
+		my $pid = interchange_pid();
+		print errmsg(
+				"Queued jobs=%s for cat %s; Interchange server %s will run them on its next housekeeping pass.\n",
+				$Vend::JobsJob,
+				$Vend::JobsCat,
+				$pid,
+			) unless $Vend::Quiet;
+		exit 0;
+	}
+
 	control_interchange('jobs', 'HUP');
 }
 
@@ -132,8 +144,11 @@ sub signal_add {
 	control_interchange('add', 'HUP');
 }
 
-sub control_interchange {
-	my ($mode, $sig, $restart) = @_;
+# Return the pid of the running Interchange server, determined the same
+# way control_interchange always has. Exits (or returns undef when
+# $restart is set) if the server is not running.
+sub interchange_pid {
+	my ($restart) = @_;
 
 	$Vend::ControllingInterchange = 1;
 	unless(-f $Global::PIDfile) {
@@ -159,6 +174,14 @@ EOF
 		exit 1 unless $restart;
 		return;
 	}
+	return $pid;
+}
+
+sub control_interchange {
+	my ($mode, $sig, $restart) = @_;
+
+	my $pid = interchange_pid($restart)
+		or return;
 	if(! $sig) {
 		$sig = $mode ne 'kill' ? 'TERM' : 'KILL';
 	}

--- a/lib/Vend/Control.pm
+++ b/lib/Vend/Control.pm
@@ -77,9 +77,45 @@ sub signal_jobs {
 		$parmsstr = ' '. join (' ', @parms);
 	}
 	
-	Vend::Util::writefile("$Global::RunDir/jobsqueue", "jobs $cat $delay $job$parmsstr\n");
+	write_jobsqueue("jobs $cat $delay $job$parmsstr\n");
 #::logGlobal("signal_jobs: wrote file, ready to control_interchange");
 	control_interchange('jobs', 'HUP');
+}
+
+# Append to the jobsqueue file under lock. The server's housekeeping
+# consumes and unlinks the queue under the same lock; if that happens
+# while we wait for the lock, our handle points to a dead inode and the
+# line would be lost, so re-verify the path after locking and retry.
+sub write_jobsqueue {
+	my ($line) = @_;
+	my $file = "$Global::RunDir/jobsqueue";
+
+	for (;;) {
+		open(my $fh, '>>', $file)
+			or die errmsg("Couldn't open %s: %s\n", $file, $!);
+		lockfile($fh, 1, 1)
+			or die errmsg("Couldn't lock %s: %s\n", $file, $!);
+
+		my @fh_stat = stat($fh);
+		my @path_stat = stat($file);
+		if (! @path_stat
+			or $fh_stat[0] != $path_stat[0]
+			or $fh_stat[1] != $path_stat[1])
+		{
+			unlockfile($fh);
+			close $fh;
+			next;
+		}
+
+		seek($fh, 0, 2)
+			or die errmsg("Couldn't seek %s: %s\n", $file, $!);
+		print $fh $line
+			or die errmsg("Couldn't write %s: %s\n", $file, $!);
+		unlockfile($fh)
+			or die errmsg("Couldn't unlock %s: %s\n", $file, $!);
+		close $fh;
+		return 1;
+	}
 }
 
 sub signal_remove {

--- a/lib/Vend/Payment.pm
+++ b/lib/Vend/Payment.pm
@@ -420,8 +420,14 @@ sub charge {
                     || 'Due to technical difficulties, your order could not be processed.';
                 local $SIG{ALRM} = sub { die "$to_msg\n" };
 
+                # waitpid the specific gateway child, retrying on EINTR
+                # with the alarm still armed: an unrelated signal must not
+                # cancel the timeout protection or reap the wrong process.
                 alarm $timeout;
-                wait;
+                my $reaped;
+                do {
+                    $reaped = waitpid($pid, 0);
+                } until $reaped == $pid or ($reaped == -1 and not $!{EINTR});
                 alarm 0;
 
                 $pid = undef;

--- a/lib/Vend/Server.pm
+++ b/lib/Vend/Server.pm
@@ -1236,6 +1236,7 @@ sub connection {
 
 my $Signal_Terminate;
 my $Signal_Restart;
+my $Signal_Reopen_Log;
 my %orig_signal;
 my @trapped_signals = qw(INT TERM HUP USR1 USR2);
 
@@ -1305,6 +1306,16 @@ sub sig_int_or_term {
 
 sub sig_hup {
     $Signal_Restart = 1;
+    $Signal_Reopen_Log = 1;
+}
+
+# Reopen the debug log at a safe point in the server loops rather than
+# in sig_hup itself: under PERL_SIGNALS=unsafe (the default), doing
+# filehandle operations inside the handler can corrupt or segfault
+# whatever the process was executing when the signal arrived.
+sub reopen_log_on_hup {
+    return unless $Signal_Reopen_Log;
+    undef $Signal_Reopen_Log;
     my $am_master = ($Vend::MasterProcess == $$);
     warn "Re-opening log...\n" if $am_master;
     setup_debug_log(!$am_master);
@@ -2199,6 +2210,7 @@ sub server_page {
 	  my ($ok, $p, $v);
 	  my $i = 0;
 	  $c++;
+	  reopen_log_on_hup();
 	  eval {
 		$rin = $p_vector;
 		
@@ -2365,6 +2377,7 @@ sub server_soap {
 	  my $n;
 	  $c++;
 	  my ($ok, $p, $v);
+	  reopen_log_on_hup();
 	  eval {
 		$rin = $s_vector;
 
@@ -2784,6 +2797,7 @@ sub server_both {
 
 	  my $i = 0;
 	  $c++;
+	  reopen_log_on_hup();
 	  eval {
         if($only_ipc) {
 			$rin = $ipc_vector;

--- a/lib/Vend/Server.pm
+++ b/lib/Vend/Server.pm
@@ -1427,8 +1427,8 @@ sub housekeeping {
 			for my $pid (@starting_pids) {
 				my $time_taken = $check_time - $Starting_pids{$pid};
 				if ($time_taken > $start_max_time) {
-					::logDebug("pid $pid took $time_taken seconds to start ($start_max_time allowed); scheduling for death");
-					$bad_pids{$pid} = undef;
+					$bad_pids{$pid} = ::errmsg('took %s seconds to start (%s allowed)', $time_taken, $start_max_time);
+					::logGlobal("page server pid %s %s; scheduling for termination", $pid, $bad_pids{$pid});
 					delete $Starting_pids{$pid};
 					--$starting_count;
 				}
@@ -1438,7 +1438,7 @@ sub housekeeping {
 #::logDebug("too many pids ($active_count)");
 				my $bad = shift @active_pids;
 #::logDebug("scheduling %s for death", $bad);
-				$bad_pids{$bad} = undef;
+				$bad_pids{$bad} = ::errmsg('excess server (%s active, StartServers %s)', $active_count, $Global::StartServers);
 				--$active_count;
 			}
 
@@ -1457,7 +1457,8 @@ sub housekeeping {
 					next unless $last_use > $Global::PIDcheck;
 #::logDebug('pid %s last used %d seconds ago', $pid, $last_use);
 					if ($pid_stats->[1]) {
-						$bad_pids{$pid} = undef;
+						$bad_pids{$pid} = ::errmsg('busy in one request for %s seconds (PIDcheck %s)', $last_use, $Global::PIDcheck);
+						::logGlobal("page server pid %s %s; scheduling for termination", $pid, $bad_pids{$pid});
 						delete $Page_pids{$pid};
 #::logDebug('scheduling %s for death', $pid);
 						--$active_count;
@@ -1477,12 +1478,13 @@ sub housekeeping {
 				start_page(undef, $Global::PreFork, $server_deficit);
 			}
 
-			for my $pid (@Termed_pids) {
+			for (@Termed_pids) {
+				my ($pid, $why) = @$_;
 				kill (KILL => $pid)
-					and ::logDebug("Sent $pid a KILL");
+					and ::logGlobal("page server pid %s ignored TERM (%s); sent KILL", $pid, $why);
 			}
-			::logGlobal("page server pid %s won't die!", $_)
-					for grep { kill (0, $_) } @Termed_pids;
+			::logGlobal("page server pid %s won't die!", $_->[0])
+					for grep { kill (0, $_->[0]) } @Termed_pids;
 			@Termed_pids = ();
 
 			if (%bad_pids) {
@@ -1496,8 +1498,8 @@ sub housekeeping {
 					)
 				{
 					kill (TERM => $pid);
-					::logDebug("Sent $pid a TERM");
-					push (@Termed_pids, $pid);
+					::logDebug("Sent %s a TERM: %s", $pid, $bad_pids{$pid});
+					push (@Termed_pids, [$pid, $bad_pids{$pid}]);
 				}
 			}
 		}

--- a/scripts/interchange.PL
+++ b/scripts/interchange.PL
@@ -431,6 +431,17 @@ This will NOT work:
 
 	interchange --runjobs=foundation --jobgroup=weekly
 
+=item --queuejobs=catalog[=job]
+
+Same as --runjobs, except no signal is sent to the running Interchange
+server. The job is written to the job queue and the server picks it up
+on its next housekeeping pass, i.e. within the HouseKeeping interval.
+
+This is useful when jobs are scheduled frequently on a PreFork system:
+each --runjobs invocation signals the server with HUP, which the
+server relays to every pooled page server, while --queuejobs disturbs
+nothing. The signal is not needed for the jobs to run in either case.
+
 =item -d dir, --dir=dir
 
 Directory for VendRoot. This is where the Interchange configuration file
@@ -569,6 +580,9 @@ Command line options (first letter will usually work):
      --jobgroup=jobname    job group to run (hourly, daily, weekly, etc.)
      --kill [signal]       kill server ungracefully (9 or with optional signal)
      -q, --quiet           suppress informational messages on startup
+     --queuejobs=catalog[=job]  queue jobs like --runjobs, but without
+                           signaling the server; jobs start on the
+                           server's next housekeeping pass
      --reconfig=catalog    reconfig a particular catalog on the server
      --remove=catalog      remove a catalog from operation
      -r, --restart         restart server
@@ -661,6 +675,7 @@ sub parse_options {
 		flag			=> \$Vend::JobsFlag,
 		jobgroup		=> \$Vend::JobsJob,
 		runjobs			=> \&signal_jobs,
+		queuejobs		=> \&signal_jobs,
 		remove			=> \&signal_remove,
 		kill			=> \&control_interchange,
 		Ignore 			=> \$ignore,
@@ -733,6 +748,7 @@ sub parse_options {
         quiet|q
         rundir=s
 		runjobs=s
+		queuejobs=s
 		pidfile=s
 		reconfig=s
 		remove=s


### PR DESCRIPTION
## Problem

On a production PreFork site, frequent `--runjobs` invocations caused intermittent, completely silent page server deaths, surfacing as customer-facing 500s mid-checkout (in the worst case after the payment gateway had already captured funds).

The mechanism: `--runjobs` sends HUP to the master, which relays it to every pooled page server from housekeeping. Page servers inherit `sig_hup`, whose body calls `setup_debug_log` — closing and reopening `Vend::DEBUG` and re-dupping STDIN/STDOUT/STDERR — directly in the signal handler. Under `PERL_SIGNALS=unsafe` (the `bin/interchange` default, kept so alarms can interrupt blocking gateway/DB calls), that runs at C-signal level mid-opcode inside whatever the page server was executing: a recipe for intermittent memory corruption or segfault, which produces no Perl-level logging at all — just a dead process, a closed socket to the link program, and a 500. Note the handler body is never a no-op: even with no `DebugFile` configured, `setup_debug_log` still closes and re-dups the three standard handles, so every PreFork install is exposed via any HUP source (log rotation, `--reconfig`, `--add`/`--remove`, jobs).

## Fixes

- **Defer HUP debug log reopen out of the signal handler** — `sig_hup` now only sets a flag, the same minimal shape as the TERM/INT handlers; the reopen runs between requests (page/SOAP servers) or between housekeeping passes (master). This is the root-cause fix, covering all HUP sources.
- **Log page server kills in PreFork housekeeping** — abnormal kills (slow start, PIDcheck busy) and TERM-ignored KILL escalations now reach the global error log with the reason; routine excess-server retirements stay at debug level. These paths were previously silent at production log levels, which is why the deaths above were so hard to find.
- **Keep payment timeout armed when wait is interrupted** — `Vend::Payment::charge` used bare `alarm; wait; alarm 0`, so any signal interrupting `wait` silently cancelled the gateway timeout and then blocked unprotected in `$pipe->getlines` with the child left a zombie. Now `waitpid`s the specific child, retrying on EINTR with the alarm still armed.
- **Fix race losing queued jobs** — `signal_jobs` appended to `jobsqueue` with an open-then-lock sequence; if housekeeping consumed and unlinked the queue while the writer waited on the lock, the job line landed on a dead inode and was silently lost. The new `write_jobsqueue` re-verifies the inode after locking and retries.
- **Add `--queuejobs=catalog[=job]`** — opt-in variant of `--runjobs` that writes the queue entry without signaling the server. The HUP is not needed for job pickup (housekeeping scans the queue every pass and the signal cannot make that happen sooner), so on PreFork systems that schedule frequent jobs this avoids interrupting every page server once per job. Server-liveness feedback is preserved via the PID file check shared with `control_interchange`.

## Testing

- `perl -c` clean on all touched files at every commit (branch bisects cleanly).
- `write_jobsqueue` exercised standalone: create/append under lock, plus a forked-writer simulation of the consume-and-unlink race confirming the inode recheck lands the line in the recreated queue file.
- The signal-handler analysis and fix shape were validated against a production incident where the direct queue-write mitigation (equivalent to `--queuejobs`) eliminated the failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)